### PR TITLE
Add a way to generate dynamic libraries and dynamically linked binaries

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -116,3 +116,13 @@ endif
 LIBARITH = $(BUILD_DIR)/libarith.a
 LIBEC = $(BUILD_DIR)/libec.a
 LIBSIGN = $(BUILD_DIR)/libsign.a
+
+# Compile dynamic libraries if the user asked to
+ifeq ($(WITH_DYNAMIC_LIBS),1)
+# Dynamic libraries to produce or link to
+LIBARITH_DYN = $(BUILD_DIR)/libarith.so
+LIBEC_DYN = $(BUILD_DIR)/libec.so
+LIBSIGN_DYN = $(BUILD_DIR)/libsign.so
+# The flag to generate shared librarie
+LIB_DYN_CFLAGS ?= -shared -Wl,-z,relro,-z,now
+endif

--- a/src/examples/Makefile
+++ b/src/examples/Makefile
@@ -6,6 +6,10 @@ include $(ROOT_DIR)/common.mk
 CFLAGS += -I$(ROOT_DIR)/src/ -I$(ROOT_DIR)/src/external_deps
 
 all:	nn_example fp_example curve_basic_examples curve_ecdh
+ifeq ($(WITH_DYNAMIC_LIBS),1)
+# If the user asked for dynamic libraries, compile versions of our binaries against them
+all:	nn_example_dyn fp_example_dyn curve_basic_examples_dyn curve_ecdh_dyn
+endif
 
 nn_example:
 	$(CC) $(BIN_CFLAGS) -DNN_EXAMPLE nn_miller_rabin.c nn_pollard_rho.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(LIBARITH) $(BIN_LDFLAGS) -o nn_pollard_rho
@@ -18,7 +22,24 @@ curve_basic_examples:
 curve_ecdh:
 	$(CC) $(BIN_CFLAGS) -DCURVE_ECDH curve_ecdh.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(BIN_LDFLAGS) $(LIBEC) -o curve_ecdh
 
+
+# If the user asked for dynamic libraries, compile versions of our binaries against them
+ifeq ($(WITH_DYNAMIC_LIBS),1)
+nn_example_dyn:
+	$(CC) $(BIN_CFLAGS) -DNN_EXAMPLE nn_miller_rabin.c nn_pollard_rho.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(BIN_LDFLAGS) -L$(BUILD_DIR) -larith -o nn_pollard_rho_dyn
+
+fp_example_dyn:
+	$(CC) $(BIN_CFLAGS) -DFP_EXAMPLE nn_miller_rabin.c fp_square_residue.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(BIN_LDFLAGS) -L$(BUILD_DIR) -larith -o fp_square_residue_dyn
+
+curve_basic_examples_dyn:
+	$(CC) $(BIN_CFLAGS) -DCURVE_BASIC_EXAMPLES fp_square_residue.c curve_basic_examples.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(ROOT_DIR)/src/external_deps/time.c  $(BIN_LDFLAGS) -L$(BUILD_DIR) -lec -o curve_basic_examples_dyn
+curve_ecdh_dyn:
+	$(CC) $(BIN_CFLAGS) -DCURVE_ECDH curve_ecdh.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(BIN_LDFLAGS) -L$(BUILD_DIR) -lec -o curve_ecdh_dyn
+endif
+
+
 clean:
 	@rm -f nn_pollard_rho fp_square_residue curve_basic_examples curve_ecdh
+	@rm -f nn_pollard_rho_dyn fp_square_residue_dyn curve_basic_examples_dyn curve_ecdh_dyn
 
 .PHONY: all clean 16 32 64 debug debug16 debug32 debug64 force_arch32 force_arch64


### PR DESCRIPTION
through the Makefile, in addition to static archives.

Generating these elements is as easy as exporting WITH_DYNAMIC_LIBS=1:

$ WITH_DYNAMIC_LIBS=1 make

This is true for the main build as well as for the provided examples.